### PR TITLE
Added keyword, id and handling for multiple maintenance items

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,20 +43,44 @@ If no fqdn specified, the local host name is used
 
 ```
 python zabbix_maintenance.py start
-python zabbix_maintenance.py start 0.25
-python zabbix_maintenance.py start 0.25 zabbix.example.com
+python zabbix_maintenance.py start -t 0.25
+python zabbix_maintenance.py start -t 0.25 -s zabbix.example.com
 ```
 
 ### Remove a maintenance period
 
 ```
 python zabbix_maintenance.py stop
-python zabbix_maintenance.py stop 3 zabbix.example.com
+python zabbix_maintenance.py stop -s zabbix.example.com
 ```
 
 ### Check if a maintenance for host exist on zabbix
 
 ```
 python zabbix_maintenance.py check
-python zabbix_maintenance.py check zabbix.example.com
+python zabbix_maintenance.py check -s zabbix.example.com
+```
+
+## Additional usage for zabbix_maintenance_v7.py
+
+### Add a maintenance with keyword (works currently only on zabbix_maintenance_v7.py)
+
+This helps to prevent overwriting/deleting mutliple maintenance items.
+
+```
+python zabbix_maintenance_v7.py start -t 0.25 -k "apt" -s zabbix.example.com
+# delete the maintenance item with keyword
+python zabbix_maintenance_v7.py stop -k "apt" -s zabbix.example.com
+```
+
+### Remove a maintenance period only with id (works currently only on zabbix_maintenance_v7.py)
+
+```
+# first, show all items and their ids
+python zabbix_maintenance_v7.py check -s zabbix.example.com
+# output example:
+#  121: maintenance_zabbix.example.com_apt
+#  122: maintenance_zabbix.example.com_malu
+#  123: maintenance_zabbix.example.com
+python zabbix_maintenance_v7.py stop -s zabbix.example.com -i 123
 ```

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ If no fqdn specified, the local host name is used
 
 ```
 python zabbix_maintenance.py start
-python zabbix_maintenance.py start 3
-python zabbix_maintenance.py start 3 zabbix.example.com
+python zabbix_maintenance.py start 0.25
+python zabbix_maintenance.py start 0.25 zabbix.example.com
 ```
 
 ### Remove a maintenance period

--- a/zabbix_maintenance_v7.py
+++ b/zabbix_maintenance_v7.py
@@ -27,8 +27,7 @@ parser.add_argument(
     nargs="?",
     type=float,
     default=None,
-    help=""
-    "Number of hours for maintenance (only for start/stop). Maximum is 148159 hours.",
+    help="Number of hours for maintenance (only for start/stop). Maximum is 148159 hours."
 )
 parser.add_argument(
     "--target-host",
@@ -36,7 +35,7 @@ parser.add_argument(
     nargs="?",
     type=str,
     default=None,
-    help="" "Target host to set or check maintenance",
+    help="Target host to set or check maintenance"
 )
 parser.add_argument(
     "--config-file",
@@ -44,9 +43,8 @@ parser.add_argument(
     nargs="?",
     type=str,
     default=None,
-    help=""
-    r'Path of the config file (default of Windows "C:\ProgramData\zabbix\zabbix_maintenance.yml"'
-    ', on Linux "/etc/zabbix/zabbix_maintenance.yml")',
+    help=r'Path of the config file (default of Windows "C:\ProgramData\zabbix\zabbix_maintenance.yml"'
+    ', on Linux "/etc/zabbix/zabbix_maintenance.yml")'
 )
 parser.add_argument(
     "--keyword",
@@ -54,7 +52,7 @@ parser.add_argument(
     nargs="?",
     type=str,
     default=None,
-    help="" "Add a keyword for the maintenance item.",
+    help="Add a keyword for the maintenance item."
 )
 parser.add_argument(
     "--delete-all",
@@ -62,7 +60,7 @@ parser.add_argument(
     nargs="?",
     type=bool,
     default=False,
-    help="" "Delete all maintenance items. Works only for 'stop' action.",
+    help="Delete all maintenance items. Works only for 'stop' action."
 )
 args = parser.parse_args()
 

--- a/zabbix_maintenance_v7.py
+++ b/zabbix_maintenance_v7.py
@@ -229,7 +229,8 @@ def get_host_id(host):
 def get_maintenance_id(hostid, maintenance_name):
     """get maintenanceid with filter on 'maintenance_name'"""
     # If keyword is None, then show all maintenance items for specified target host
-    # If keyword is an empty sting (like 'check -k ""'), then show only the item which matches with hostname in it's name
+    # If keyword is an empty sting (like 'check -k ""'), then show only the item which
+    # matches with hostname in it's name
     # If keyword is provided (not empty), then search for exact matching name
     json = {
         "jsonrpc": "2.0",
@@ -268,7 +269,6 @@ def get_maintenance_id(hostid, maintenance_name):
         print("Follow maintenance item(s) was found:")
         for maintenanceids, maintenancename in maintenanceid.items():
             print(f"{maintenanceids}: {maintenancename}")
-        # print(f'Maintenance "{maintenance_name}" with maintenanceid "{maintenanceid}" found for host "{hostname}".')
         return maintenanceid
     except (requests.exceptions.HTTPError, requests.exceptions.RequestException) as err:
         handle_request_execption(err)
@@ -353,7 +353,8 @@ match args.action:
                 del_maintenance(mid)
         else:
             print(
-                'Multiple maintenance items was found, please use "--keyword, -k" or "--delete-all, -rm" to specify your request.\n'
+                'Multiple maintenance items was found, '
+                'please use "--keyword, -k" or "--delete-all, -rm" to specify your request.\n'
             )
             sys.exit(1)
     case "start":
@@ -367,7 +368,8 @@ match args.action:
             create_maintenance(MAINTENANCE_NAME, now, until, host_id, PERIOD)
         else:
             print(
-                'Multiple maintenance items was found, please use "--keyword, -k" to specify your request.\n'
+                'Multiple maintenance items was found, '
+                'please use "--keyword, -k" to specify your request.\n'
             )
             sys.exit(1)
 

--- a/zabbix_maintenance_v7.py
+++ b/zabbix_maintenance_v7.py
@@ -14,16 +14,55 @@ import requests
 
 
 # --- argument parser ---
-parser = argparse.ArgumentParser(description='Tool to start, ' \
-'stop or check maintenance for a specific host on zabbix')
-parser.add_argument('action', choices=['start', 'stop', 'check'], help='Action to perform')
-parser.add_argument('--time-period', '-t', nargs='?', type=float, default=None, help='' \
-'Number of hours for maintenance (only for start/stop). Maximum is 148159 hours.')
-parser.add_argument('--target-host', '-s', nargs='?', type=str, default=None, help='' \
-'Target host to set or check maintenance')
-parser.add_argument('--config-file', '-c', nargs='?', type=str, default=None, help='' \
-r'Path of the config file (default of Windows "C:\ProgramData\zabbix\zabbix_maintenance.yml"' \
-', on Linux "/etc/zabbix/zabbix_maintenance.yml")')
+parser = argparse.ArgumentParser(
+    description="Tool to start, "
+    "stop or check maintenance for a specific host on zabbix"
+)
+parser.add_argument(
+    "action", choices=["start", "stop", "check"], help="Action to perform"
+)
+parser.add_argument(
+    "--time-period",
+    "-t",
+    nargs="?",
+    type=float,
+    default=None,
+    help=""
+    "Number of hours for maintenance (only for start/stop). Maximum is 148159 hours.",
+)
+parser.add_argument(
+    "--target-host",
+    "-s",
+    nargs="?",
+    type=str,
+    default=None,
+    help="" "Target host to set or check maintenance",
+)
+parser.add_argument(
+    "--config-file",
+    "-c",
+    nargs="?",
+    type=str,
+    default=None,
+    help=""
+    r'Path of the config file (default of Windows "C:\ProgramData\zabbix\zabbix_maintenance.yml"'
+    ', on Linux "/etc/zabbix/zabbix_maintenance.yml")',
+)
+parser.add_argument(
+    "--keyword",
+    "-k",
+    nargs="?",
+    type=str,
+    default=None,
+    help="" "Add a keyword for the maintenance item.",
+)
+parser.add_argument(
+    "--delete-all",
+    nargs="?",
+    type=bool,
+    default=False,
+    help="" "Delete all maintenance items. Works only for 'stop' action.",
+)
 args = parser.parse_args()
 
 
@@ -31,9 +70,9 @@ args = parser.parse_args()
 # determine config file path
 if args.config_file is not None:
     CONFIG_PATH = args.config_file
-elif platform.system() == 'Windows':
+elif platform.system() == "Windows":
     CONFIG_PATH = r"C:\ProgramData\zabbix\zabbix_maintenance.yml"
-elif platform.system() == 'Linux':
+elif platform.system() == "Linux":
     CONFIG_PATH = "/etc/zabbix/zabbix_maintenance.yml"
 else:
     CONFIG_PATH = "/etc/zabbix/zabbix_maintenance.yml"
@@ -81,7 +120,11 @@ password = config["password"]
 server = config["server"]
 API_URL = f"https://{server}/api_jsonrpc.php"
 # set maintenance object name
-MAINTENANCE_NAME = f"maintenance_{hostname}"
+# if keyword was provided, use it as suffix in object name
+if args.keyword:
+    MAINTENANCE_NAME = f"maintenance_{hostname}_{args.keyword}"
+else:
+    MAINTENANCE_NAME = f"maintenance_{hostname}"
 
 now = int(time.time())
 until = int(time.mktime((datetime.now() + timedelta(seconds=PERIOD)).timetuple()))
@@ -89,36 +132,34 @@ until = int(time.mktime((datetime.now() + timedelta(seconds=PERIOD)).timetuple()
 
 # --- functions ---
 
+
 def handle_zabbix_error(data):
     """Check for zabbix API error"""
-    if 'error' in data:
-        error = data['error']
+    if "error" in data:
+        error = data["error"]
         print(f"Zabbix API Error {error['code']}: {error['message']}")
         print(f"\t Details: {error['data']}")
         logout_user()
-        return True # error found
-    return False # no error found
+        return True  # error found
+    return False  # no error found
 
 
 def handle_request_execption(err):
     """handle errors for requests"""
-    print('An error occured during the request:')
-    print(f'\t Type: {type(err).__name__}')
-    print(f'\t Message: {err}')
+    print("An error occured during the request:")
+    print(f"\t Type: {type(err).__name__}")
+    print(f"\t Message: {err}")
     logout_user()
 
 
 def login_api_user():
     """Login user and return auth token"""
-    headers = {'Content-Type': 'application/json-rpc'}
+    headers = {"Content-Type": "application/json-rpc"}
     json = {
-        'jsonrpc': '2.0',
-        'method': 'user.login',
-        'params': {
-            'username': user,
-            'password': password
-        },
-        'id': 1
+        "jsonrpc": "2.0",
+        "method": "user.login",
+        "params": {"username": user, "password": password},
+        "id": 1,
     }
     try:
         r = requests.post(API_URL, json=json, headers=headers, timeout=5)
@@ -126,7 +167,7 @@ def login_api_user():
         data = r.json()
         if handle_zabbix_error(data):
             return None
-        auth_token = data['result']
+        auth_token = data["result"]
         return auth_token
     except (requests.exceptions.HTTPError, requests.exceptions.RequestException) as err:
         handle_request_execption(err)
@@ -136,13 +177,13 @@ def login_api_user():
 def logout_user():
     """Because of user.login, we have to proper logout the user to prevent too many open sessions"""
     json = {
-        'jsonrpc': '2.0',
-        'method': 'user.logout',
-        'params': [],
-        'auth': token,
-        'id': 1
+        "jsonrpc": "2.0",
+        "method": "user.logout",
+        "params": [],
+        "auth": token,
+        "id": 1,
     }
-    headers = {'Content-Type': 'application/json-rpc'}
+    headers = {"Content-Type": "application/json-rpc"}
     try:
         r = requests.post(API_URL, json=json, headers=headers, timeout=5)
         r.raise_for_status()
@@ -158,31 +199,26 @@ def logout_user():
 def get_host_id(host):
     """get hostid from zabbix server"""
     json = {
-        'jsonrpc': '2.0',
-        'method': 'host.get',
-        'params': {
-            'filter': {
-                'host': host
-            },
-        'output': 'extend'
-        },
-        'auth': token,
-        'id': 1
+        "jsonrpc": "2.0",
+        "method": "host.get",
+        "params": {"filter": {"host": host}, "output": "extend"},
+        "auth": token,
+        "id": 1,
     }
-    headers = {'Content-Type': 'application/json-rpc'}
+    headers = {"Content-Type": "application/json-rpc"}
     try:
         r = requests.post(API_URL, json=json, headers=headers, timeout=5)
         r.raise_for_status()
         data = r.json()
         if handle_zabbix_error(data):
             return None
-        result = data['result']
+        result = data["result"]
         if not result:
             print(f'Host "{hostname}" not found!')
             logout_user()
             sys.exit(2)
         else:
-            hostid = result[0]['hostid']
+            hostid = result[0]["hostid"]
             return hostid
     except (requests.exceptions.HTTPError, requests.exceptions.RequestException) as err:
         handle_request_execption(err)
@@ -192,34 +228,43 @@ def get_host_id(host):
 def get_maintenance_id(hostid, maintenance_name):
     """get maintenanceid with filter on 'maintenance_name'"""
     json = {
-        'jsonrpc': '2.0',
-        'method': 'maintenance.get',
-        'params': {
-            'output': 'extend',
-            'selectGroups': 'extend',
-            'selectTimeperiods': 'extend',
-            'hostids': hostid,
-            'search': {
-                'name': maintenance_name
-            },
-            'startSearch': 'true'
+        "jsonrpc": "2.0",
+        "method": "maintenance.get",
+        "params": {
+            "output": "extend",
+            "selectGroups": "extend",
+            "selectTimeperiods": "extend",
+            "hostids": hostid,
+            "search": {"name": maintenance_name},
+            "startSearch": "true",
+            # "startSearch": "true" if args.keyword is None else "false",
+            # "searchWildcardsEnabled": "false" if args.keyword is None else "true",
         },
-        'auth': token,
-        'id': 1
+        "auth": token,
+        "id": 1,
     }
-    headers = {'Content-Type': 'application/json-rpc'}
+    print(json)
+    headers = {"Content-Type": "application/json-rpc"}
     try:
         r = requests.post(API_URL, json=json, headers=headers, timeout=5)
         r.raise_for_status()
         data = r.json()
         if handle_zabbix_error(data):
             return None
-        result = data['result']
+        result = data["result"]
         if not result:
-            print(f'Host "{hostname}" with hostid "{hostid}" has no maintenance defined.')
+            print(
+                f'Host "{hostname}" with hostid "{hostid}" has no maintenance defined.'
+            )
             return None
-        maintenanceid = result[0]['maintenanceid']
-        print(f'Maintenance "{maintenance_name}" with maintenanceid "{maintenanceid}" found for host "{hostname}".')
+        # Marco Lucarelli:
+        # maintenanceid = result[0]['maintenanceid']
+        # collect all "maintenanceid", "name" results and create dict
+        maintenanceid = {m["maintenanceid"]: m["name"] for m in result}
+        print(f"Follow maintenance item(s) was found:")
+        for mid, mname in maintenanceid.items():
+            print(f"{mid}: {mname}")
+        # print(f'Maintenance "{maintenance_name}" with maintenanceid "{maintenanceid}" found for host "{hostname}".')
         return maintenanceid
     except (requests.exceptions.HTTPError, requests.exceptions.RequestException) as err:
         handle_request_execption(err)
@@ -229,20 +274,22 @@ def get_maintenance_id(hostid, maintenance_name):
 def del_maintenance(maintenanceid):
     """delete existing maintenance object"""
     json = {
-        'jsonrpc': '2.0',
-        'method': 'maintenance.delete',
-        'params': [maintenanceid],
-        'auth': token,
-        'id': 1
+        "jsonrpc": "2.0",
+        "method": "maintenance.delete",
+        "params": [maintenanceid],
+        "auth": token,
+        "id": 1,
     }
-    headers = {'Content-Type': 'application/json-rpc'}
+    headers = {"Content-Type": "application/json-rpc"}
     try:
         r = requests.post(API_URL, json=json, headers=headers, timeout=5)
         r.raise_for_status()
         data = r.json()
         if handle_zabbix_error(data):
             return None
-        print(f'Successfully deleted maintenance object with maintenanceid "{maintenanceid}"')
+        print(
+            f'Successfully deleted maintenance object with maintenanceid "{maintenanceid}"'
+        )
         return True
     except (requests.exceptions.HTTPError, requests.exceptions.RequestException) as err:
         handle_request_execption(err)
@@ -252,29 +299,28 @@ def del_maintenance(maintenanceid):
 def create_maintenance(maintenance_name, since, till, hostid, timeperiod):
     """create maintenance object with period"""
     json = {
-        'jsonrpc': '2.0',
-        'method': 'maintenance.create',
-        'params': {
-            'name': maintenance_name,
-            'active_since': since,
-            'active_till': till,
-            'hostids': [hostid],
-            'timeperiods': {
-                'period': timeperiod,
-                'timeperiod_type': 0
-            }
+        "jsonrpc": "2.0",
+        "method": "maintenance.create",
+        "params": {
+            "name": maintenance_name,
+            "active_since": since,
+            "active_till": till,
+            "hostids": [hostid],
+            "timeperiods": {"period": timeperiod, "timeperiod_type": 0},
         },
-        'auth': token,
-        'id': 1
+        "auth": token,
+        "id": 1,
     }
-    headers = {'Content-Type': 'application/json-rpc'}
+    headers = {"Content-Type": "application/json-rpc"}
     try:
         r = requests.post(API_URL, json=json, headers=headers, timeout=5)
         r.raise_for_status()
         data = r.json()
         if handle_zabbix_error(data):
             return None
-        print(f'Added a {timeperiod//3600}:{timeperiod%3600//60:02n} hour maintenance on host "{hostname}"')
+        print(
+            f'Added a {timeperiod//3600}:{timeperiod%3600//60:02n} hour maintenance on host "{hostname}"'
+        )
         return True
     except (requests.exceptions.HTTPError, requests.exceptions.RequestException) as err:
         handle_request_execption(err)
@@ -292,14 +338,34 @@ if args.action == "check":
 elif args.action == "stop":
     host_id = get_host_id(hostname)
     maintenance_id = get_maintenance_id(host_id, MAINTENANCE_NAME)
-    if maintenance_id is not None:
-        del_maintenance(maintenance_id)
+    if maintenance_id is None:
+        print(f"Nothing to do.")
+    elif args.delete_all:
+        for mid, mname in maintenance_id.items():
+            del_maintenance(mid)
+    elif len(maintenance_id) == 1:
+        for mid, mname in maintenance_id.items():
+            del_maintenance(mid)
+    else:
+        print(
+            f'Multiple maintenance items was found, please use "--keyword" or "--delete-all" to specify your request.\n'
+        )
+        sys.exit(1)
 elif args.action == "start":
     host_id = get_host_id(hostname)
     maintenance_id = get_maintenance_id(host_id, MAINTENANCE_NAME)
-    if maintenance_id is not None:
-        del_maintenance(maintenance_id)
-    create_maintenance(MAINTENANCE_NAME, now, until, host_id, PERIOD)
+    if maintenance_id is None:
+        create_maintenance(MAINTENANCE_NAME, now, until, host_id, PERIOD)
+    elif len(maintenance_id) == 1:
+        for mid, mname in maintenance_id.items():
+            del_maintenance(mid)
+        create_maintenance(MAINTENANCE_NAME, now, until, host_id, PERIOD)
+    else:
+        print(
+            f'Multiple maintenance items was found, please use "--keyword" to specify your request.\n'
+        )
+        parser.print_help()
+        sys.exit(1)
 
 # always log user out
 logout_user()

--- a/zabbix_maintenance_v7.py
+++ b/zabbix_maintenance_v7.py
@@ -58,6 +58,7 @@ parser.add_argument(
 )
 parser.add_argument(
     "--delete-all",
+    "-rm",
     nargs="?",
     type=bool,
     default=False,
@@ -236,13 +237,37 @@ def get_maintenance_id(hostid, maintenance_name):
             "selectTimeperiods": "extend",
             "hostids": hostid,
             "search": {"name": maintenance_name},
-            "startSearch": "true",
             # "startSearch": "true" if args.keyword is None else "false",
             # "searchWildcardsEnabled": "false" if args.keyword is None else "true",
         },
         "auth": token,
         "id": 1,
     }
+    print(json)
+    match args.keyword:
+        case None:
+            print(f'args.keyword is None')
+            json["params"]["startSearch"] = "true"
+        case "":
+            print(f'args.keyword == ""')
+            json["params"]["startSearch"] = "false"
+            json["params"]["searchWildcardsEnabled"] = "false"
+        case _:
+            print(f'args.keyword is not None')
+            json["params"]["startSearch"] = "false"
+            json["params"]["searchWildcardsEnabled"] = "false"
+    
+    # if args.keyword is None:
+    #     print(f'args.keyword is None')
+    #     json["params"]["startSearch"] = "true"
+    #     json["params"]["searchWildcardsEnabled"] = "false"
+    # elif args.keyword == "":
+    #     print(f'args.keyword == ""')
+    #     json["params"]["startSearch"] = "false"
+    # elif args.keyword is not None:
+    #     print(f'args.keyword is not None')
+    #     json["params"]["startSearch"] = "false"
+    #     json["params"]["searchWildcardsEnabled"] = "false"
     print(json)
     headers = {"Content-Type": "application/json-rpc"}
     try:

--- a/zabbix_maintenance_v7.py
+++ b/zabbix_maintenance_v7.py
@@ -57,9 +57,7 @@ parser.add_argument(
 parser.add_argument(
     "--delete-all",
     "-rm",
-    nargs="?",
-    type=bool,
-    default=False,
+    action="store_true",
     help="Delete all maintenance items. Works only for 'stop' action."
 )
 args = parser.parse_args()


### PR DESCRIPTION
Code is enough documentation. Just kidding, I added follow feature:
* `--keyword, -k`. Maintenance item name has a suffix, so we can have mutliple maintenance items and change them without to interrupt the others.
* `--delete-all, -rm`. Delete all maintenance items for specified host.
* `--id, -i`. Delete maintenance item with provided id.
* If more then one maintenance item was found, you have to specify the item before it can be deleted, expect if you add `--delete-all`.
